### PR TITLE
Add a script for alignment of all ChIP-seq fastq.gz in a directory.

### DIFF
--- a/align_all.sh
+++ b/align_all.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+for tag in `ls *.fastq.gz | awk -F"." '{print $1}' | tr '\n' ' '` 
+do 
+    ./bowtie2_align.sh $tag hg19 $tag.fastq.gz
+done
+


### PR DESCRIPTION
Created a small script that automates alignment of all ChIP-seq fastq.gz files in a directory where the script is launched. It uses bowtie2_align.sh script.
