### PR TITLE
Add mv_srr.sh

### DIFF
--- a/mv_srr.sh
+++ b/mv_srr.sh
@@ -1,0 +1,23 @@
+#!/bin/bash 
+
+## add a mark to SRR file names corresponding to the given GSM
+
+mark=$1
+GSM=$2
+ext=$3
+
+echo "Getting the following exeriments for $GSM:" 
+esearch -db sra -query $GSM | efetch -format runinfo | awk -F "," '{if (NR>1) printf "%s\t%s\t%s\n",$1,$13,$14}' | grep -v "^\s*$"
+SRRS=`esearch -db sra -query $GSM | efetch -format runinfo | awk -F "," '{if (NR>1) print $1}' | grep -v "^\s*$"`
+SRXS=`esearch -db sra -query $GSM | efetch -format runinfo | awk -F "," '{if (NR>1) print $13}' | grep -v "^\s*$"`
+
+a=( $SRRS ) 
+b=( $SRXS ) 
+N=${#a[@]}
+M=${#b[@]}
+
+for i in `seq 0 $((N-1))`
+do
+     mv "${a[$i]}.$ext" "$mark.${a[$i]}.$ext"
+done   
+


### PR DESCRIPTION
Wrote a script for adding a ChIP-seq mark name to all SRR file names corresponding to a given GSM.
E. g., if GSM733691 is an H3K27ac ChIP-seq experiment, then all SRR files downloaded from GSM733691 will be renamed to have 'H3K27ac' at the beginning of their name. File extension should also be provided (e. g., if it is 'tdf', then all TDF files corresponding to the given GSM will be renamed).