### PR TITLE
Add mv_srr_all.py

### DIFF
--- a/mv_srr_all.py
+++ b/mv_srr_all.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python
+
+import sys
+import subprocess
+
+gsm_mark_list = sys.argv[1]
+ext = sys.argv[2]
+with open(gsm_mark_list, 'r') as infile:
+    for line in infile:
+        gsm, mark = line.strip().split('\t')
+        subprocess.Popen(['./mv_srr.sh', mark, gsm, ext])
+

--- a/mv_srr_all.py
+++ b/mv_srr_all.py
@@ -7,6 +7,6 @@ gsm_mark_list = sys.argv[1]
 ext = sys.argv[2]
 with open(gsm_mark_list, 'r') as infile:
     for line in infile:
-        gsm, mark = line.strip().split('\t')
+        mark, gsm = line.strip().split('\t')
         subprocess.Popen(['./mv_srr.sh', mark, gsm, ext])
 


### PR DESCRIPTION
Added a script mv_srr_all.py that enables a user to rename all SRR files (fastq, bam, bed or other type) at once in order to add mark symbols to their names. First argument should be a tab-delimited file with a list of marks and according GSMs, e. g.,

hESC_mark_gsm_list.txt:

H3K4me1 GSM733782
H3K4me2 GSM733670
H3K4me3	 GSM733657
H3K9ac GSM733773
H3K9me3	 GSM1003585
H3K27ac GSM733718

The second argument is an extension of files to rename, e. g., 'fastq' or 'bam'. So, if SRR227415 dataset is contained, e. g., in GSM733782, then using command 

./mv_srr_all.py hESC_mark_gsm_list.txt bam

file SRR227415.bam will be automatically renamed to H3K4me1.SRR227415.bam. All other bam files whose SRRs are contained in GSMs from the list will be renamed accordingly.

