### PR TITLE
Add mv_gsm_all.py

### DIFF
--- a/mv_gsm_all.py
+++ b/mv_gsm_all.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python
+
+import sys
+import subprocess
+
+gsm_mark_list = sys.argv[1]
+ext = sys.argv[2]
+with open(gsm_mark_list, 'r') as infile:
+    for line in infile:
+        mark, gsm = line.strip().split('\t')
+        subprocess.Popen(['mv', gsm + '.' + ext, mark + '.' + gsm + '.' + ext])
+


### PR DESCRIPTION
Added mv_gsm_all.py script that enables a user to rename files like GSM1234567.{fastq, bam, ...} to mark.GSM1234567.{fastq, bam, ...}. The first argument must be a tab-delimited list of marks and corresponding GSMs, e. g.:

H3K4me1 GSM1234567
H3K4me1 GSM3214567
H4K20me1 GSM9876543

The second arguments is an extension of files that should be renamed.
